### PR TITLE
Update to Craft 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,9 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
-    "craftcms/cms": "^4.0.0"
+    "php": ">=8.2",
+    "craftcms/cms": "^5.0.0"
   },
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://asset-packagist.org"
-    }
-  ],
   "autoload": {
     "psr-4": {
       "humandirect\\cookiebot\\": "src/"

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -25,7 +25,7 @@ class Settings extends Model
     {
         return [
             ['domainGroupID', 'string'],
-            ['domainGroupID', 'default', 'value' => null],
+            ['domainGroupID', 'default', 'value' => ''],
             ['defaultPreferences', 'boolean'],
             ['defaultPreferences', 'default', 'value' => false],
             ['defaultStatistics', 'boolean'],

--- a/src/services/CookiebotService.php
+++ b/src/services/CookiebotService.php
@@ -24,7 +24,7 @@ class CookiebotService extends Component
      */
     public function requiresConsent(): bool
     {
-        return !$this->isCookieSet() || ($this->isCookieSet() && '-1' !== $_COOKIE[self::COOKIE_NAME]);
+        return !$this->isCookieSet() || ('-1' !== $_COOKIE[self::COOKIE_NAME]);
     }
 
     /**


### PR DESCRIPTION
Bumps the version requirement to `^5.0.0` and fixes the one bug I encountered. Technically the plugin doesn't need any changes at all, so the version requirement could easily be `^4.0.0|^5.0.0`. Let me know if that's desired.